### PR TITLE
zvmsdk & zthin RPM version should also contain the build date info

### DIFF
--- a/zthin_rhel.spec
+++ b/zthin_rhel.spec
@@ -1,9 +1,10 @@
 %define name zthin
+%define _buildnum %(date +%Y%m%d%H%M)
 
 Summary: System z hardware control point (zThin)
 Name: %{name}
 Version: %(cat Version)
-Release: 11.ibm%{?dist}
+Release: 11.ibm.%{_buildnum}%{?dist}
 Source: zthin-build.tar.gz
 Vendor: IBM
 License: ASL 2.0

--- a/zvmsdk_rhel.spec
+++ b/zvmsdk_rhel.spec
@@ -1,9 +1,10 @@
 %define name python-zvm-sdk
+%define _buildnum %(date +%Y%m%d%H%M)
 
 Summary: IBM z/VM cloud connector
 Name: %{name}
 Version: 1.5.0
-Release: 11.ibm%{?dist}
+Release: 11.ibm.%{_buildnum}%{?dist}
 Source: python-zvm-sdk.tar.gz
 Vendor: IBM
 License: ASL 2.0


### PR DESCRIPTION
zvmsdk & zthin RPM version should also contain the build date info

https://github.ibm.com/zvc/planning/issues/2042