### PR TITLE
[1.1.1-hot-1]add ubuntu service file copy

### DIFF
--- a/zvmsdk_rhel.spec
+++ b/zvmsdk_rhel.spec
@@ -35,6 +35,7 @@ mkdir -p %{buildroot}/var/opt/zvmsdk
 cp zvmsdklogs %{buildroot}/var/opt/zvmsdk
 cp tools/share/zvmguestconfigure  %{buildroot}/var/lib/zvmsdk/
 cp tools/share/zvmguestconfigure.service %{buildroot}/var/lib/zvmsdk/
+cp tools/share/zvmguestconfigure.service.ubuntu %{buildroot}/var/lib/zvmsdk/
 
 %clean
 rm -rf %{buildroot}
@@ -43,6 +44,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root)
 /var/lib/zvmsdk/zvmguestconfigure
 /var/lib/zvmsdk/zvmguestconfigure.service
+/var/lib/zvmsdk/zvmguestconfigure.service.ubuntu
 %dir %attr(0755, zvmsdk, zvmsdk) /etc/zvmsdk
 %dir %attr(0755, zvmsdk, zvmsdk) /var/log/zvmsdk
 %dir %attr(0755, zvmsdk, zvmsdk) /var/opt/zvmsdk


### PR DESCRIPTION
PR for add zvmguestconfigure.service.ubuntu:
https://github.com/openmainframeproject/python-zvm-sdk/pull/292

Issue:
https://github.ibm.com/zvc/planning/issues/2527

Add a zvmguestconfigure service file for ubuntu. 
Set 'DefaultDependency = No' to remove cycle depends on sysinit with cloud-init-local.

@dyyang @wghaojue please help to review, thanks.