### PR TITLE
update zthin version number for 1.1.3 hotfix 1

### DIFF
--- a/zthin_rhel.spec
+++ b/zthin_rhel.spec
@@ -4,7 +4,7 @@
 Summary: System z hardware control point (zThin)
 Name: %{name}
 Version: %(cat Version)
-Release: 13.ibm.%{_buildnum}IF11301%{?dist}
+Release: 12.ibm.%{_buildnum}IF11301%{?dist}
 Source: zthin-build.tar.gz
 Vendor: IBM
 License: ASL 2.0

--- a/zthin_rhel.spec
+++ b/zthin_rhel.spec
@@ -4,7 +4,7 @@
 Summary: System z hardware control point (zThin)
 Name: %{name}
 Version: %(cat Version)
-Release: 11.ibm.%{_buildnum}%{?dist}
+Release: 13.ibm.%{_buildnum}IF11301%{?dist}
 Source: zthin-build.tar.gz
 Vendor: IBM
 License: ASL 2.0

--- a/zthin_rhel.spec
+++ b/zthin_rhel.spec
@@ -11,6 +11,7 @@ License: ASL 2.0
 Group: System/tools
 BuildRoot: %{_tmppath}/zthin
 Prefix: /opt/zthin
+requires:       rsyslog
 
 %description
 The System z hardware control point (zThin) is a set of APIs to interface with


### PR DESCRIPTION
because 1.1.3 still use version number 3.1.2-11, so 1.1.3 hotfix 1 will use 3.1.2-12. 
and there are codes in zthin rpm spec file to enabled rsyslog logging, and what's missed is just its dependency on rsyslog, so added the dependency, and this means we will only need to update zthin rpm for the hotfix to achieve both goals of us:
(1) fix the refresh_bootmap issue.  (2) fix the zthin logging and rotation issue.

issue: https://github.ibm.com/zvc/planning/issues/6058