### PR TITLE
update release number for zthin plugin

### DIFF
--- a/zthin_rhel.spec
+++ b/zthin_rhel.spec
@@ -4,13 +4,14 @@
 Summary: System z hardware control point (zThin)
 Name: %{name}
 Version: %(cat Version)
-Release: 11.ibm.%{_buildnum}%{?dist}
+Release: 114.1.ibm.%{_buildnum}%{?dist}
 Source: zthin-build.tar.gz
 Vendor: IBM
 License: ASL 2.0
 Group: System/tools
 BuildRoot: %{_tmppath}/zthin
 Prefix: /opt/zthin
+requires:       rsyslog
 
 %description
 The System z hardware control point (zThin) is a set of APIs to interface with


### PR DESCRIPTION
https://github.ibm.com/zvc/planning/issues/6221

change the release number to align with noarch and multiarch rpms and also add dependency to rsyslog as we did for the 1.1.3 hotfix 1. 